### PR TITLE
fix parsing player markets

### DIFF
--- a/library/src/main/java/com/oddin/oddsfeedsdk/schema/feed/v1/OFOddsChangeMarket.java
+++ b/library/src/main/java/com/oddin/oddsfeedsdk/schema/feed/v1/OFOddsChangeMarket.java
@@ -247,6 +247,9 @@ public class OFOddsChangeMarket implements FeedMessageMarket {
      */
     @NotNull
     public String getSpecifiers() {
+        if (specifiers == null) {
+            return "";
+        }
         return specifiers;
     }
 

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/api/ApiClient.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/api/ApiClient.kt
@@ -219,7 +219,7 @@ class ApiClientImpl @Inject constructor(
     }
 
     override suspend fun fetchMarketDescriptionsWithDynamicOutcomes(marketTypeId: Int, marketVariant: String, locale: Locale): List<RAMarketDescription> {
-        val data: RAMarketDescriptions = fetchData("/descriptions/${locale.language}/markets/${marketTypeId}/variant/${marketVariant}", locale)
+        val data: RAMarketDescriptions = fetchData("/descriptions/${locale.language}/markets/${marketTypeId}/variants/${marketVariant}", locale)
         return data.market
     }
 


### PR DESCRIPTION
Issue 1 - wrong url

Issue 2 - NotNull annotation caused invalid state exception for message:

```xml
<odds_change timestamp="0" product="0" event_id="od:match:0">
    <odds>
        <market id="101" status="1">
            <outcome id="61" odds="0" probabilities="0" active="1"></outcome>
            <outcome id="60" odds="0" probabilities="0" active="1"></outcome>
        </market>
    </odds>
</odds_change>
```

the specifiers would be serialized into null