### PR TITLE
Additional error logging

### DIFF
--- a/examples/src/main/java/com/oddin/oddsfeed/examples/Main.java
+++ b/examples/src/main/java/com/oddin/oddsfeed/examples/Main.java
@@ -248,7 +248,7 @@ public class Main {
             Match match = liveMatches.get(0);
             System.out.println("Live match: " + match.getName(Locale.getDefault()) + ", " + match.getId());
             System.out.println("Match Status: " + match.getStatus());
-            System.out.println("Match Status 2 : " + match.getStatus().getStatus());
+            System.out.println("Event Status: " + match.getStatus().getStatus());
         }
 
         try {

--- a/examples/src/main/java/com/oddin/oddsfeed/examples/Main.java
+++ b/examples/src/main/java/com/oddin/oddsfeed/examples/Main.java
@@ -242,6 +242,15 @@ public class Main {
             }
         }
 
+        List<Match> liveMatches = sportsInfoManager.getLiveMatches();
+        System.out.println(liveMatches);
+        if (liveMatches != null && !liveMatches.isEmpty()) {
+            Match match = liveMatches.get(0);
+            System.out.println("Live match: " + match.getName(Locale.getDefault()) + ", " + match.getId());
+            System.out.println("Match Status: " + match.getStatus());
+            System.out.println("Match Status 2 : " + match.getStatus().getStatus());
+        }
+
         try {
             // Sleep for 30 minutes
             Thread.sleep(1000 * 30 * 60);

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/OddsFeed.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/OddsFeed.kt
@@ -179,7 +179,7 @@ class OddsFeed {
             injector.getInstance(CacheManager::class.java).close()
             injector.getInstance(ApiClient::class.java).close()
         } catch (e: Exception) {
-            logger.error { "Failed to close with $e" }
+            logger.error(e) { "Failed to close" }
         }
 
         logger.debug { "Odds feed closed " }

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/OddsFeedSession.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/OddsFeedSession.kt
@@ -68,7 +68,7 @@ open class OddsFeedSessionImpl @Inject constructor(
                 try {
                     feedMessageReceived(it, messageInterest, oddsFeedListener)
                 } catch (e: Exception) {
-                    logger.error { "Failed to process message ${it.message}" }
+                    logger.error(e) { "Failed to process message ${it.message}" }
                     publishUnparsableMessage(it)
                 }
             }, {
@@ -225,7 +225,7 @@ open class OddsFeedSessionImpl @Inject constructor(
             val message = feedMessageFactory.buildUnparsableMessage<SportEvent>(feedMessage)
             dispatchManager.publish(message)
         } catch (e: Exception) {
-            logger.error { "Failed to publish unparsable message $e" }
+            logger.error(e) { "Failed to publish unparsable message" }
         }
     }
 }

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/RecoveryManager.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/RecoveryManager.kt
@@ -268,7 +268,7 @@ class RecoveryManagerImpl @Inject constructor(
                 try {
                     callable(producerName, eventId, requestId, oddsFeedConfiguration.sdkNodeId)
                 } catch (e: Exception) {
-                    logger.error { "Event recovery failed with $e" }
+                    logger.error(e) { "Event recovery failed" }
                     false
                 }
             }
@@ -372,7 +372,7 @@ class RecoveryManagerImpl @Inject constructor(
                     recoverFrom?.toEpochMilli(),
                 )
             } catch (e: Exception) {
-                logger.error { "Recovery failed with $e" }
+                logger.error(e) { "Recovery failed" }
                 false
             }
         }

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/ReplayManager.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/ReplayManager.kt
@@ -87,7 +87,7 @@ class ReplayManagerImpl @Inject constructor(
             try {
                 apiClient.deleteReplayEvent(id, oddsFeedConfiguration.sdkNodeId)
             } catch (e: Exception) {
-                logger.error(e) { "Failed to add event id $id" }
+                logger.error(e) { "Failed to remove event id $id" }
                 false
             }
         }
@@ -177,7 +177,7 @@ class ReplayManagerImpl @Inject constructor(
                     runParallel = runParallel
                 )
             } catch (e: Exception) {
-                logger.error(e) { "Failed play replay" }
+                logger.error(e) { "Failed to play replay" }
                 false
             }
         }

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/ReplayManager.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/ReplayManager.kt
@@ -53,7 +53,7 @@ class ReplayManagerImpl @Inject constructor(
             try {
                 apiClient.fetchReplaySetContent(oddsFeedConfiguration.sdkNodeId)
             } catch (e: Exception) {
-                logger.error { "Failed to fetch replay events with error $e" }
+                logger.error(e) { "Failed to fetch replay events" }
                 null
             }
         }
@@ -71,7 +71,7 @@ class ReplayManagerImpl @Inject constructor(
             try {
                 apiClient.putReplayEvent(id, oddsFeedConfiguration.sdkNodeId)
             } catch (e: Exception) {
-                logger.error { "Failed to add event id $id with error $e" }
+                logger.error(e) { "Failed to add event id $id" }
                 false
             }
         }
@@ -87,7 +87,7 @@ class ReplayManagerImpl @Inject constructor(
             try {
                 apiClient.deleteReplayEvent(id, oddsFeedConfiguration.sdkNodeId)
             } catch (e: Exception) {
-                logger.error { "Failed to add event id $id with error $e" }
+                logger.error(e) { "Failed to add event id $id" }
                 false
             }
         }
@@ -142,7 +142,7 @@ class ReplayManagerImpl @Inject constructor(
             try {
                 apiClient.postReplayStop(oddsFeedConfiguration.sdkNodeId)
             } catch (e: Exception) {
-                logger.error { "Failed to stop replay with $e" }
+                logger.error(e) { "Failed to stop replay" }
                 false
             }
         }
@@ -153,7 +153,7 @@ class ReplayManagerImpl @Inject constructor(
             try {
                 apiClient.postReplayClear(oddsFeedConfiguration.sdkNodeId)
             } catch (e: Exception) {
-                logger.error { "Failed to clear replay with $e" }
+                logger.error(e) { "Failed to clear replay" }
                 false
             }
         }
@@ -177,7 +177,7 @@ class ReplayManagerImpl @Inject constructor(
                     runParallel = runParallel
                 )
             } catch (e: Exception) {
-                logger.error { "Failed play replay with errror $e" }
+                logger.error(e) { "Failed play replay" }
                 false
             }
         }

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/CompetitorCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/CompetitorCache.kt
@@ -107,7 +107,7 @@ class CompetitorCacheImpl @Inject constructor(
                 try {
                     refreshOrInsertItem(id, it, data)
                 } catch (e: Exception) {
-                    logger.error { "Failed to refresh or insert competitor" }
+                    logger.error(e) { "Failed to refresh or insert competitor" }
                 }
             }
         }

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/MatchCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/MatchCache.kt
@@ -107,7 +107,7 @@ class MatchCacheImpl @Inject constructor(
                 try {
                     refreshOrInsertItem(id, it, data.sportEvent)
                 } catch (e: Exception) {
-                    logger.error { "Failed to refresh or insert match: ${e.message}" }
+                    logger.error(e) { "Failed to refresh or insert match" }
                 }
             }
         }

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/MatchStatusCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/MatchStatusCache.kt
@@ -101,7 +101,7 @@ class MatchStatusCacheImpl @Inject constructor(
             try {
                 refreshOrInsertFeedItem(id, message.sportEventStatus)
             } catch (e: Exception) {
-                logger.error { "Failed to process message in match status cache - $message" }
+                logger.error(e) { "Failed to process message in match status cache - $message" }
             }
         }
     }

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/PlayerCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/PlayerCache.kt
@@ -98,7 +98,7 @@ class PlayerCacheImpl @Inject constructor(
                 try {
                     refreshOrInsertItem(id, it, data)
                 } catch (e: Exception) {
-                    logger.error { "Failed to refresh or insert player" }
+                    logger.error(e) { "Failed to refresh or insert player" }
                 }
             }
         }

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/SportDataCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/SportDataCache.kt
@@ -110,7 +110,7 @@ class SportDataCacheImpl @Inject constructor(
                     try {
                         refreshOrInsertItem(id, locale, tournamentId = it)
                     } catch (e: Exception) {
-                        logger.error { "Failed to refresh or insert tournament to sport" }
+                        logger.error(e) { "Failed to refresh or insert tournament to sport" }
                     }
                 }
 
@@ -147,7 +147,7 @@ class SportDataCacheImpl @Inject constructor(
                     try {
                         refreshOrInsertItem(id, locale, sport = it)
                     } catch (e: Exception) {
-                        logger.error { "Failed to insert or refresh sport" }
+                        logger.error(e) { "Failed to insert or refresh sport" }
                     }
                 }
 

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/TournamentCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/TournamentCache.kt
@@ -115,7 +115,7 @@ class TournamentCacheImpl @Inject constructor(
                 try {
                     refreshOrInsertItem(id, it, data)
                 } catch (e: Exception) {
-                    logger.error { "Failed to refresh or load tournament" }
+                    logger.error(e) { "Failed to refresh or load tournament" }
                 }
             }
         }
@@ -127,7 +127,7 @@ class TournamentCacheImpl @Inject constructor(
             try {
                 refreshOrInsertItem(id, locale, it)
             } catch (e: Exception) {
-                logger.error { "Failed to refresh or load tournament" }
+                logger.error(e) { "Failed to refresh or load tournament" }
             }
         }
     }

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/market/MarketDescriptionCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/market/MarketDescriptionCache.kt
@@ -133,7 +133,7 @@ class MarketDescriptionCacheImpl @Inject constructor(
                     try {
                         refreshOrInsertItem(it, locale)
                     } catch (e: Exception) {
-                        logger.error { "Failed to refresh or insert market: $e" }
+                        logger.error(e) { "Failed to refresh or insert market" }
                     }
                 }
 


### PR DESCRIPTION
From Tipsport when updating to prev. version 0.0.47

Hi, so, since the new release, we seem to be getting a lot of errors:
Failed to process message com.oddin.oddsfeedsdk.schema.feed.v1.OFOddsChange@2684639
Failed to process message com.oddin.oddsfeedsdk.schema.feed.v1.OFFixtureChange@4cddafe4
Failed to process message com.oddin.oddsfeedsdk.schema.feed.v1.OFBetSettlement@51d856f0
but there is nothing more, so it is hard for us to know what is going on.. could you please look at it as well as add stack_trace to the error? because this message does not say much https://github.com/oddin-gg/javasdk/blob/develop/library/src/main/kotlin/com/oddin/oddsfeedsdk/OddsFeedSession.kt#L71
also, everytime we call sportsInfoManager.getLiveMatches(), we get nullPointer when calling match.getStatus().getStatus(), which did not happen before the update