### PR TITLE
Add CI publish to GitHub Packages Maven

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - 'main'
       - 'develop'
+    tags:
+      - 'v*'
 
 jobs:
   build_and_test_library:
@@ -63,3 +65,30 @@ jobs:
       - name: Build and Test the Examples
         run: ./gradlew build
         working-directory: ./examples
+
+  publish_maven:
+    name: Publish to GitHub Packages
+    needs: [build_and_test_library, build_and_test_examples]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 8 with Gradle Cache
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'corretto'
+          cache: 'gradle'
+
+      - name: Publish to GitHub Packages
+        run: ./gradlew publish
+        working-directory: ./library
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -68,6 +68,16 @@ publishing {
             from components.java
         }
     }
+    repositories {
+        maven {
+            name = "OddinGitHubPackages"
+            url = uri("https://maven.pkg.github.com/oddin-gg/javasdk")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }
 
 task install(dependsOn: publishToMavenLocal)


### PR DESCRIPTION
## Summary
- Add Maven publish step to CI pipeline, triggered on `v*` tags
- Configure GitHub Packages Maven repository in Gradle build
- Publish runs after build & test jobs pass, using `GITHUB_TOKEN` for auth

## Test plan
- [ ] Push a `v*` tag and verify the workflow triggers
- [ ] Confirm package appears under repo's Packages tab


🤖 Generated with [Claude Code](https://claude.com/claude-code)