### PR TITLE
feat(ci): export JaCoCo coverage report for Coverage Dashboard [CORE-3368]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'gradle'
 
       - name: Build and Install the Library
-        run: ./gradlew install
+        run: ./gradlew test jacocoTestReport install
         working-directory: ./library
 
       - name: Upload to Local Maven Repository
@@ -38,6 +38,13 @@ jobs:
         with:
           name: local-maven-repo
           path: ~/.m2/repository
+
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: library/build/reports/jacoco/test/jacocoTestReport.xml
+          if-no-files-found: warn
 
   build_and_test_examples:
     name: Build & Test Examples

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java-library'
     id 'com.palantir.git-version' version '0.12.2'
     id 'maven-publish'
+    id 'jacoco'
 }
 
 group 'com.oddin.oddsfeed'
@@ -81,3 +82,21 @@ publishing {
 }
 
 task install(dependsOn: publishToMavenLocal)
+
+jacoco {
+    toolVersion = "0.8.8"
+}
+
+test {
+    useJUnit()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+        csv.required.set(false)
+    }
+}

--- a/library/src/test/kotlin/com/oddin/oddsfeedsdk/CoverageBootstrapTest.kt
+++ b/library/src/test/kotlin/com/oddin/oddsfeedsdk/CoverageBootstrapTest.kt
@@ -1,0 +1,12 @@
+package com.oddin.oddsfeedsdk
+
+import org.junit.Test
+
+// CORE-3368: bootstrap test so the test JVM actually starts and JaCoCo can emit a
+// coverage report covering the SDK's classes. Replace with real test cases as
+// the SDK gains test coverage.
+class CoverageBootstrapTest {
+    @Test
+    fun bootstrap() {
+    }
+}


### PR DESCRIPTION
Wires up JaCoCo so javasdk appears on the Grafana Coverage Dashboard, matching the existing setup of `gosdk` (which also has no real tests today but ships a zero-coverage Go textfmt profile via `go test -cover ./...`).

## Why a code change (and not just CI)

Unlike Go's `go test -cover ./...`, which walks every package and emits a `mode: set` profile with all-zero entries even when no `_test.go` files exist, **JaCoCo is runtime instrumentation** — it captures execution data only while a test JVM is actually running. With zero test classes JUnit doesn't start a runner, JaCoCo never sees any SDK class load, and the report is empty.

To get the equivalent shape (all SDK classes enumerated, 0% covered) two pieces are needed:

1. **One bootstrap test** so JUnit starts a runner. Without it the `test` task is a no-op and `jacocoTestReport` has no execution data to report on.
2. **JaCoCo's `classDirectories` default** — Gradle's `jacoco` plugin defaults `jacocoTestReport.classDirectories` to `sourceSets.main.output`, which means **all** SDK classes appear in the report, not just classes that were loaded during the test run. So unloaded classes correctly show as 0% covered, not as missing.

The bootstrap test is replaceable — when real test cases land, they replace it and the same JaCoCo wiring keeps producing reports with real numbers.

## Verified shape (from this PR's CI run)

CI build succeeded; `coverage-report` artifact contains a 1.1 MB `jacocoTestReport.xml`:

```
20 packages, 533 classes enumerated
LINE counter   : 5081 missed, 0 covered  (= 5,081 lines, 0% covered)
BRANCH counter : 1728 missed, 0 covered
METHOD counter : 2195 missed, 0 covered
CLASS counter  :  398 missed, 0 covered
```

After merge, skald's daily 06:00 Prague poll downloads this artifact, autodetects the JaCoCo format (filename `jacocoTestReport.xml` matches skald's accepted list), parses the LINE counter, and writes a row to `mart_grafana.coverage_reports`. The dashboard will show `oddin-gg/javasdk` at 5,081 lines / 0% — same shape as `oddin-gg/gosdk` today.

## What's in the diff

- **`library/build.gradle`** — apply the `jacoco` plugin, set `toolVersion = "0.8.8"`, configure `test` to be `finalizedBy jacocoTestReport`, configure `jacocoTestReport` to emit XML at the default path (`build/reports/jacoco/test/jacocoTestReport.xml`).
- **`library/src/test/kotlin/com/oddin/oddsfeedsdk/CoverageBootstrapTest.kt`** — a single empty `@Test fun bootstrap()` to make JUnit start. Replaceable.
- **`.github/workflows/ci.yml`** — replace `./gradlew install` with `./gradlew test jacocoTestReport install`, add an `actions/upload-artifact` step uploading `library/build/reports/jacoco/test/jacocoTestReport.xml` as `coverage-report`.

## Compared to smoke

Different shape than smoke. Smoke has real unit + system tests, uploads merged Go covdata + Cobertura xml, and shows real coverage numbers (~60%). javasdk after this PR mirrors gosdk's "no tests yet, ship zero-coverage to make the gap visible on the dashboard" pattern — not smoke's "instrumented end-to-end" pattern. When real tests land later, the wiring already works and the numbers populate accordingly.

[Link to JIRA ticket](https://oddingg.atlassian.net/browse/CORE-3368)