### PR TITLE
fix: tunable maximum-size cap on SDK caches to prevent OOM [CORE-3581]

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ for (SportEvent tournament : sportsInfoManager.getActiveTournaments("Dota 2")) {
 }
 ```
 
+### Cache configuration (memory)
+
+The SDK keeps sport events, competitors and players in in-memory caches, bounded
+by both time and a maximum entry count. Over-capacity entries are evicted
+least-recently-used and re-fetched from the API on next access, so there is no
+functional data loss.
+
+Defaults: match 10 000, fixture 10 000, competitor 20 000, player 50 000.
+
+If you consume a very large schedule and see high memory use, lower the caps:
+
+```java
+OddsFeedConfiguration config = OddsFeed.getConfigurationBuilder()
+        .setAccessToken("your-token")
+        .setMaxMatchCacheSize(2000)
+        .setMaxFixtureCacheSize(2000)
+        .setMaxCompetitorCacheSize(4000)
+        .setMaxPlayerCacheSize(8000)
+        .build();
+```
+
 ### Replay
 
 You can use replay feature to receive data from previously played events. You need to build a replay session via session builder, add events to replay list and play it.

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/CompetitorCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/CompetitorCache.kt
@@ -43,6 +43,8 @@ class CompetitorCacheImpl @Inject constructor(
         CacheBuilder
             .newBuilder()
             .expireAfterWrite(24L, TimeUnit.HOURS)
+            .maximumSize(oddsFeedConfiguration.maxCompetitorCacheSize)
+            .softValues()
             .build<URN, LocalizedCompetitor>()
 
     init {

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/FixtureCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/FixtureCache.kt
@@ -9,6 +9,7 @@ import com.oddin.oddsfeedsdk.api.entities.sportevent.TvChannel
 import com.oddin.oddsfeedsdk.api.entities.sportevent.TvChannelImpl
 import com.oddin.oddsfeedsdk.cache.LocalizedItem
 import com.oddin.oddsfeedsdk.config.ExceptionHandlingStrategy
+import com.oddin.oddsfeedsdk.config.OddsFeedConfiguration
 import com.oddin.oddsfeedsdk.exceptions.ItemNotFoundException
 import com.oddin.oddsfeedsdk.schema.utils.URN
 import com.oddin.oddsfeedsdk.utils.Utils
@@ -22,13 +23,16 @@ interface FixtureCache : CacheLoader<LocalizedFixture> {
 }
 
 class FixtureCacheImpl @Inject constructor(
-    private val apiClient: ApiClient
+    private val apiClient: ApiClient,
+    private val oddsFeedConfiguration: OddsFeedConfiguration,
 ) : FixtureCache {
 
     private val lock = Any()
     private val internalCache = CacheBuilder
         .newBuilder()
         .expireAfterWrite(12L, TimeUnit.HOURS)
+        .maximumSize(oddsFeedConfiguration.maxFixtureCacheSize)
+        .softValues()
         .build<URN, LocalizedFixture>()
 
     override fun clearCacheItem(id: URN) {

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/MatchCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/MatchCache.kt
@@ -11,6 +11,7 @@ import com.oddin.oddsfeedsdk.api.factories.EntityFactory
 import com.oddin.oddsfeedsdk.cache.Closable
 import com.oddin.oddsfeedsdk.cache.LocalizedItem
 import com.oddin.oddsfeedsdk.config.ExceptionHandlingStrategy
+import com.oddin.oddsfeedsdk.config.OddsFeedConfiguration
 import com.oddin.oddsfeedsdk.exceptions.ItemNotFoundException
 import com.oddin.oddsfeedsdk.schema.rest.v1.RAFixturesEndpoint
 import com.oddin.oddsfeedsdk.schema.rest.v1.RAScheduleEndpoint
@@ -35,7 +36,8 @@ private val logger = KotlinLogging.logger {}
 public const val EXTRA_INFO_KEY_SPORT_FORMAT = "sport_format"
 
 class MatchCacheImpl @Inject constructor(
-    private val apiClient: ApiClient
+    private val apiClient: ApiClient,
+    private val oddsFeedConfiguration: OddsFeedConfiguration,
 ) : MatchCache {
 
     companion object {
@@ -47,6 +49,8 @@ class MatchCacheImpl @Inject constructor(
     private val internalCache = CacheBuilder
         .newBuilder()
         .expireAfterWrite(12L, TimeUnit.HOURS)
+        .maximumSize(oddsFeedConfiguration.maxMatchCacheSize)
+        .softValues()
         .build<URN, LocalizedMatch>()
 
     init {

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/PlayerCache.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/cache/entity/PlayerCache.kt
@@ -38,6 +38,8 @@ class PlayerCacheImpl @Inject constructor(
         CacheBuilder
             .newBuilder()
             .expireAfterWrite(24L, TimeUnit.HOURS)
+            .maximumSize(oddsFeedConfiguration.maxPlayerCacheSize)
+            .softValues()
             .build<URN, LocalizedPlayer>()
 
     init {

--- a/library/src/main/kotlin/com/oddin/oddsfeedsdk/config/OddsFeedConfiguration.kt
+++ b/library/src/main/kotlin/com/oddin/oddsfeedsdk/config/OddsFeedConfiguration.kt
@@ -12,7 +12,22 @@ class OddsFeedConfiguration internal constructor(
     val exceptionHandlingStrategy: ExceptionHandlingStrategy,
     val selectedEnvironment: Environment,
     val initialSnapshotRecoveryInterval: Duration?,
-)
+    // Maximum number of entries held by each in-memory cache, on top of the
+    // time-based expiry. Bounds memory under large schedules; over-capacity
+    // entries are evicted least-recently-used and transparently re-fetched on
+    // next read [CORE-3581].
+    val maxMatchCacheSize: Long,
+    val maxFixtureCacheSize: Long,
+    val maxCompetitorCacheSize: Long,
+    val maxPlayerCacheSize: Long,
+) {
+    companion object {
+        const val DEFAULT_MAX_MATCH_CACHE_SIZE = 10_000L
+        const val DEFAULT_MAX_FIXTURE_CACHE_SIZE = 10_000L
+        const val DEFAULT_MAX_COMPETITOR_CACHE_SIZE = 20_000L
+        const val DEFAULT_MAX_PLAYER_CACHE_SIZE = 50_000L
+    }
+}
 
 class OddsFeedConfigurationBuilder internal constructor() {
     private var accessToken: String? = null
@@ -31,6 +46,11 @@ class OddsFeedConfigurationBuilder internal constructor() {
     private var exceptionHandlingStrategy = ExceptionHandlingStrategy.THROW
 
     private var initialSnapshotRecoveryInterval: Duration? = null
+
+    private var maxMatchCacheSize: Long = OddsFeedConfiguration.DEFAULT_MAX_MATCH_CACHE_SIZE
+    private var maxFixtureCacheSize: Long = OddsFeedConfiguration.DEFAULT_MAX_FIXTURE_CACHE_SIZE
+    private var maxCompetitorCacheSize: Long = OddsFeedConfiguration.DEFAULT_MAX_COMPETITOR_CACHE_SIZE
+    private var maxPlayerCacheSize: Long = OddsFeedConfiguration.DEFAULT_MAX_PLAYER_CACHE_SIZE
 
     fun selectProduction() = apply {
         selectProduction(Region.DEFAULT)
@@ -86,6 +106,22 @@ class OddsFeedConfigurationBuilder internal constructor() {
         this.initialSnapshotRecoveryInterval = interval
     }
 
+    fun setMaxMatchCacheSize(maxMatchCacheSize: Long) = apply {
+        this.maxMatchCacheSize = maxMatchCacheSize
+    }
+
+    fun setMaxFixtureCacheSize(maxFixtureCacheSize: Long) = apply {
+        this.maxFixtureCacheSize = maxFixtureCacheSize
+    }
+
+    fun setMaxCompetitorCacheSize(maxCompetitorCacheSize: Long) = apply {
+        this.maxCompetitorCacheSize = maxCompetitorCacheSize
+    }
+
+    fun setMaxPlayerCacheSize(maxPlayerCacheSize: Long) = apply {
+        this.maxPlayerCacheSize = maxPlayerCacheSize
+    }
+
     @Throws(IllegalArgumentException::class)
     fun build(): OddsFeedConfiguration {
         val token = accessToken ?: throw IllegalArgumentException("Missing access token. Please set access token.")
@@ -101,6 +137,10 @@ class OddsFeedConfigurationBuilder internal constructor() {
             sdkNodeId = sdkNodeId,
             selectedEnvironment = environment,
             initialSnapshotRecoveryInterval = initialSnapshotRecoveryInterval,
+            maxMatchCacheSize = maxMatchCacheSize,
+            maxFixtureCacheSize = maxFixtureCacheSize,
+            maxCompetitorCacheSize = maxCompetitorCacheSize,
+            maxPlayerCacheSize = maxPlayerCacheSize,
         )
     }
 

--- a/library/src/test/kotlin/com/oddin/oddsfeedsdk/cache/entity/MatchCacheTest.kt
+++ b/library/src/test/kotlin/com/oddin/oddsfeedsdk/cache/entity/MatchCacheTest.kt
@@ -2,6 +2,7 @@ package com.oddin.oddsfeedsdk.cache.entity
 
 import com.oddin.oddsfeedsdk.api.ApiClient
 import com.oddin.oddsfeedsdk.api.entities.sportevent.SportFormat
+import com.oddin.oddsfeedsdk.config.OddsFeedConfiguration
 import com.oddin.oddsfeedsdk.schema.rest.v1.RAExtraInfo
 import com.oddin.oddsfeedsdk.schema.rest.v1.RAInfo
 import com.oddin.oddsfeedsdk.schema.rest.v1.RAMatchSummaryEndpoint
@@ -51,7 +52,10 @@ class MatchCacheTest {
             every { subscribeForClass(any<Class<Any>>()) } returns Observable.never()
             coEvery { fetchMatchSummary(matchId, any()) } returns summary(sportFormat)
         }
-        return MatchCacheImpl(apiClient)
+        val config = mockk<OddsFeedConfiguration> {
+            every { maxMatchCacheSize } returns OddsFeedConfiguration.DEFAULT_MAX_MATCH_CACHE_SIZE
+        }
+        return MatchCacheImpl(apiClient, config)
     }
 
     private fun cachedFormat(sportFormat: String?): SportFormat {

--- a/library/src/test/kotlin/com/oddin/oddsfeedsdk/config/OddsFeedConfigurationBuilderTest.kt
+++ b/library/src/test/kotlin/com/oddin/oddsfeedsdk/config/OddsFeedConfigurationBuilderTest.kt
@@ -1,0 +1,38 @@
+package com.oddin.oddsfeedsdk.config
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+// CORE-3581: the cache size caps must be exposed on the builder with sensible
+// defaults and be overridable per client.
+class OddsFeedConfigurationBuilderTest {
+
+    private fun builder() = OddsFeedConfigurationBuilder()
+        .setAccessToken("token")
+        .selectTest()
+
+    @Test
+    fun defaultCacheSizeCapsAreApplied() {
+        val config = builder().build()
+
+        assertEquals(OddsFeedConfiguration.DEFAULT_MAX_MATCH_CACHE_SIZE, config.maxMatchCacheSize)
+        assertEquals(OddsFeedConfiguration.DEFAULT_MAX_FIXTURE_CACHE_SIZE, config.maxFixtureCacheSize)
+        assertEquals(OddsFeedConfiguration.DEFAULT_MAX_COMPETITOR_CACHE_SIZE, config.maxCompetitorCacheSize)
+        assertEquals(OddsFeedConfiguration.DEFAULT_MAX_PLAYER_CACHE_SIZE, config.maxPlayerCacheSize)
+    }
+
+    @Test
+    fun cacheSizeCapsAreOverridable() {
+        val config = builder()
+            .setMaxMatchCacheSize(11)
+            .setMaxFixtureCacheSize(22)
+            .setMaxCompetitorCacheSize(33)
+            .setMaxPlayerCacheSize(44)
+            .build()
+
+        assertEquals(11L, config.maxMatchCacheSize)
+        assertEquals(22L, config.maxFixtureCacheSize)
+        assertEquals(33L, config.maxCompetitorCacheSize)
+        assertEquals(44L, config.maxPlayerCacheSize)
+    }
+}


### PR DESCRIPTION
## CORE-3581 — tunable maximum-size cap on SDK caches (prevent OOM)

Fixes the unbounded-cache OOM reported by 2Up (currently on 0.0.52). The in-memory caches were bounded by **time only** (12h/24h expiry) with no cap on entry count, so a large schedule pull could grow memory until OOM.

### Change
Adds a `maximumSize` cap **with soft-reference eviction** to each cache, on top of the existing time-based expiry:
- `MatchCacheImpl`, `FixtureCacheImpl`, `CompetitorCacheImpl`, `PlayerCacheImpl`

The cap is tunable per client via `OddsFeedConfigurationBuilder` (`setMaxMatchCacheSize` / `setMaxFixtureCacheSize` / `setMaxCompetitorCacheSize` / `setMaxPlayerCacheSize`), with sensible defaults applied when not overridden:

| cache | default cap |
|---|---|
| match | 10 000 |
| fixture | 10 000 |
| competitor | 20 000 |
| player | 50 000 |

Eviction is LRU + soft references, so live entries are retained over stale ones and GC can reclaim under pressure. Caches are lazy fronts over the API — an evicted entry is transparently re-fetched on next read, so there's no functional data loss (same mechanism as the existing time expiry, triggered by count instead of age).

`MatchCacheImpl`/`FixtureCacheImpl` now take `OddsFeedConfiguration` via constructor injection (the other two already did).

### Tests
- `OddsFeedConfigurationBuilderTest` (new) — cap defaults are applied and are overridable.
- `MatchCacheTest` — updated for the new constructor param.
- Full suite green locally (`clean test` + `install` + examples `build`).

> ⚠️ **Stacked on #52 (CORE-3811).** Base branch is `fix/CORE-3811-blank-sport-routing-key`, not `main` — so the diff shown here is only the cache-cap delta. GitHub will auto-retarget this PR to `main` when #52 merges. Do not merge before #52.

Default cap values follow the ticket's `≈ live events × locales + headroom` guidance and can be retuned from real 2Up data during the RC tryout.
