### PR TITLE
ci: post release changelog to Slack via ragnar-notify

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,4 +10,5 @@ jobs:
     uses: oddin-gg/ragnar-notify/.github/workflows/release-changelog.yml@v0.0.6
     with:
       slack-username: javasdk
+      slack-icon-url: https://cdn.test.oddin.dev/ragnar-notify/javasdk.png
     secrets: inherit

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,13 @@
+name: Release Changelog
+run-name: Release Changelog - ${{ github.event.release.tag_name }}
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  changelog:
+    uses: oddin-gg/ragnar-notify/.github/workflows/release-changelog.yml@v0.0.6
+    with:
+      slack-username: javasdk
+    secrets: inherit


### PR DESCRIPTION
On a published GitHub Release, post the release changelog to `#product-changelog` via the shared `ragnar-notify` reusable workflow (`release-changelog.yml@v0.0.6`).

Mirrors the smoke rollout (oddin-gg/smoke#693). The `SLACK_BOT_TOKEN_CHANGELOG` repo secret is already set; the `APP_CHECKOUT_LIBRARIES_*` app creds are org-level, so nothing else is required.

---
Jira: [CORE-3922](https://oddingg.atlassian.net/browse/CORE-3922)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-3922]: https://oddingg.atlassian.net/browse/CORE-3922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ