### PR TITLE
ci: post release changelog to Slack without the internal reusable workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,14 +1,132 @@
 name: Release Changelog
 run-name: Release Changelog - ${{ github.event.release.tag_name }}
 
+# Self-contained on purpose: this repo is public, and a public repo cannot call
+# a reusable workflow (or use an action) from the internal ragnar-notify repo,
+# so the render + post steps are inlined here and Slack is called directly.
+# Keep in sync with oddin-gg/ragnar-notify/.github/workflows/release-changelog.yml.
 on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 jobs:
   changelog:
-    uses: oddin-gg/ragnar-notify/.github/workflows/release-changelog.yml@v0.0.6
-    with:
-      slack-username: javasdk
-      slack-icon-url: https://cdn.test.oddin.dev/ragnar-notify/javasdk.png
-    secrets: inherit
+    name: Post release changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Preflight — Slack token present and valid
+        env:
+          TOKEN: ${{ secrets.SLACK_BOT_TOKEN_CHANGELOG }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TOKEN:-}" ]; then
+            echo "::error title=Changelog not posted::SLACK_BOT_TOKEN_CHANGELOG is not set. Add it as a repo secret (the changelog bot token) so release changelogs can post to Slack."
+            exit 1
+          fi
+          if ! curl -sS -X POST https://slack.com/api/auth.test -H "Authorization: Bearer ${TOKEN}" | grep -q '"ok":true'; then
+            echo "::error title=Changelog not posted::SLACK_BOT_TOKEN_CHANGELOG is set but Slack rejected it (expired/revoked/wrong scope). Re-set the changelog bot token."
+            exit 1
+          fi
+
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Render changelog
+        id: render
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+          MAX_ENTRIES: "80"
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Previous release = latest published GitHub Release (git describe fallback).
+          prev="$(gh api "repos/${REPO}/releases?per_page=30" \
+            --jq "[ .[] | select(.draft == false and .prerelease == false) | .tag_name ] | map(select(. != \"${TAG}\")) | .[0] // empty" 2>/dev/null || true)"
+          if [ -z "${prev}" ]; then
+            prev="$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-rc*' "${TAG}^" 2>/dev/null || true)"
+          fi
+          range="${prev:+${prev}..}${TAG}"
+          echo "Changelog range: ${range} (previous release: ${prev:-none})"
+
+          subjects="$(git log --no-merges --pretty=format:'%s' "${range}")"
+          if [ -z "${subjects}" ]; then
+            echo "No commits in range ${range}; nothing to post."
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          total="$(printf '%s\n' "${subjects}" | grep -c '')"
+          if [ "${total}" -gt "${MAX_ENTRIES}" ]; then
+            subjects="$(printf '%s\n' "${subjects}" | sed -n "1,${MAX_ENTRIES}p")"$'\n'"…and $((total - MAX_ENTRIES)) more commits"
+          fi
+
+          # Escape & < > in the untrusted subjects (mirrors escapeSlackText in notify.go)
+          # BEFORE splicing link markup, then post the text raw — links stay live and a
+          # subject like "<!channel>" can't inject a mass-ping.
+          body="$(printf '%s\n' "${subjects}" \
+            | sed -E 's@&@\&amp;@g; s@<@\&lt;@g; s@>@\&gt;@g' \
+            | sed -E 's@\[([A-Z][A-Z0-9]+-[0-9]+)\]@[<https://oddingg.atlassian.net/browse/\1|\1>]@g' \
+            | sed -E "s@\(#([0-9]+)\)@(<https://github.com/${REPO}/pull/\1|#\1>)@g" \
+            | sed -E 's@^@• @')"
+          message="$(printf 'Released *%s*\n%s' "${TAG}" "${body}")"
+
+          {
+            echo "has_changes=true"
+            echo "message<<__CHANGELOG_EOF__"
+            printf '%s\n' "${message}"
+            echo "__CHANGELOG_EOF__"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "### Release changelog"
+            echo "- **Tag:** ${TAG}"
+            echo "- **Since:** ${prev:-<first release>}"
+            echo "- **Commits:** ${total}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "Rendered:"; printf '%s\n' "${message}"
+
+      - name: Post changelog to Slack
+        if: steps.render.outputs.has_changes == 'true'
+        env:
+          TOKEN: ${{ secrets.SLACK_BOT_TOKEN_CHANGELOG }}
+          CHANNEL: "#product-changelog"
+          SLACK_USERNAME: javasdk
+          ICON_URL: https://cdn.test.oddin.dev/ragnar-notify/javasdk.png
+          MESSAGE: ${{ steps.render.outputs.message }}
+        run: |
+          set -euo pipefail
+
+          # Same payload ragnar-notify sends in raw mode with no app-name prefix:
+          # {channel, text, username, icon_url}. jq builds it so the subjects
+          # cannot break out of the JSON string.
+          payload="$(jq -n \
+            --arg channel "${CHANNEL}" \
+            --arg text "${MESSAGE}" \
+            --arg username "${SLACK_USERNAME}" \
+            --arg icon_url "${ICON_URL}" \
+            '{channel: $channel, text: $text, username: $username, icon_url: $icon_url}')"
+
+          # Slack signals API errors as HTTP 200 + {"ok":false}, so check both the
+          # status code and .ok — mirrors the two checks in notify.go's post().
+          out="${RUNNER_TEMP}/slack-response.json"
+          code="$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            --data-binary "${payload}" \
+            -o "${out}" -w '%{http_code}')"
+
+          if [ "${code}" != "200" ] || ! jq -e '.ok' "${out}" >/dev/null 2>&1; then
+            reason="$(jq -r '.error // empty' "${out}" 2>/dev/null || true)"
+            echo "::error title=Changelog not posted::Slack chat.postMessage failed (HTTP ${code}): ${reason:-$(head -c 200 "${out}")}"
+            exit 1
+          fi
+          echo "Posted to ${CHANNEL} (ts=$(jq -r '.ts' "${out}"))"


### PR DESCRIPTION
Replaces the thin caller with a self-contained changelog workflow, because the caller can never run in this repo.

## Why

`changelog.yml` called `oddin-gg/ragnar-notify/.github/workflows/release-changelog.yml@v0.0.6`. **A public repo cannot use a reusable workflow (or an action) from a private/internal repo**, and `ragnar-notify` is `visibility=internal` while this repo is `visibility=public`.

Verified on a real release (since reverted): the run failed **at startup** — `conclusion=failure` with **0 jobs, 0 check-runs, no logs**, `run_started_at == updated_at`, and `gh run view` reporting only "This run likely failed because of a workflow file issue". It is not a config problem: `slack-icon-url` is a declared input at `v0.0.6`, the tag exists, ragnar-notify's actions access is `access_level=organization`, and `SLACK_BOT_TOKEN_CHANGELOG` is set on this repo. Positive control: the same thin caller succeeds from the private repos (kira `v0.112.1`, shujinko `v3.2.7`, daegon `v0.6.0`, fujin `v0.16.0`).

## What changed

The render step is copied from the shared workflow (pure `git` + `gh` + `sed`, no cross-repo dependency). The two steps that needed the internal repo are gone:

- `actions/create-github-app-token` + `uses: oddin-gg/ragnar-notify@v0.0.6` → a plain `curl` to `chat.postMessage`. The payload is the same shape ragnar-notify sends in raw mode with no app-name prefix (`{channel, text, username, icon_url}`, `Content-Type: application/json; charset=utf-8`), built with `jq --arg` so commit subjects can't break out of the JSON string. Both of ragnar-notify's failure checks are kept: HTTP status, then `.ok`.
- No app token means `vars.APP_CHECKOUT_LIBRARIES_ID` / `secrets.APP_CHECKOUT_LIBRARIES_PRIVATE_KEY` are no longer needed here. The only secret is the existing `SLACK_BOT_TOKEN_CHANGELOG`.

Unchanged: trigger (`release: [released]`), channel (`#product-changelog`), sender name and per-service icon, 80-entry cap, Jira/PR linkification, the escape-then-linkify ordering that neutralises `<!channel>`, and the loud preflight when the token is missing or rejected.

**One deliberate deviation from the shared workflow:** the >80-commit truncation uses `sed -n "1,80p"` instead of `head -n 80`. Under the runner's `bash -euo pipefail`, `printf … | head -n 80` exits 141 (SIGPIPE) and fails the step; `sed -n` reads all input and exits 0. Confirmed both ways locally. This is the SIGPIPE follow-up already noted against ragnar-notify#6.

## Verification

- `actionlint` clean on this file.
- Render logic run against real history of this repo (`v0.0.52..v0.0.54`): correct range from the previous **release**, Jira and PR links spliced live.
- Injection check: a subject containing `<!channel>`, `&`, and `"` renders as `&lt;!channel&gt;`, `&amp;`, JSON-escaped quotes, with link markup intact and an exact JSON round-trip.
- Truncation check: 100 subjects → 80 bullets + `…and 20 more commits`.
- **Not** end-to-end tested against Slack — the token is a repo secret, so the `chat.postMessage` call first runs for real on the next release. The preflight and the `.ok` check make a failure loud rather than silent.

Follow-up worth doing separately: options (b)/(c) from the analysis — host the shared workflow in a public repo so all 20 repos share one source of truth again, instead of three copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
